### PR TITLE
`browser.js` export `callChrome()`

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -29,11 +29,12 @@ const getOutput = async (page, request) => {
     return output.toString('base64');
 };
 
-const callChrome = async () => {
+const callChrome = async pup => {
     let browser;
     let page;
     let output;
     let remoteInstance;
+	const puppet = (pup || puppeteer);
 
     try {
         if (request.options.remoteInstanceUrl || request.options.browserWSEndpoint ) {
@@ -50,14 +51,14 @@ const callChrome = async () => {
             }
 
             try {
-                browser = await puppeteer.connect( options );
+                browser = await puppet.connect( options );
 
                 remoteInstance = true;
             } catch (exception) { /** does nothing. fallbacks to launching a chromium instance */}
         }
 
         if (!browser) {
-            browser = await puppeteer.launch({
+            browser = await puppet.launch({
                 ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
                 executablePath: request.options.executablePath,
                 args: request.options.args || []
@@ -251,4 +252,8 @@ const callChrome = async () => {
     }
 };
 
-callChrome();
+if (require.main === module) {
+	callChrome();
+}
+
+exports.callChrome = callChrome;


### PR DESCRIPTION
This PR modifies `bin/browser.js` to export `callChrome()` and enable passing in a puppeteer instance.

This allows you, when using `setBinPath()`, to create your own minimal script which configures a puppeteer instance and then calls the standard `callChrome()` with it to use the rest of Browsershot's default implementation.

**Why?**

To make it easier to use Browsershot with tools like [puppeteer-extra]() without having to completely write your own implementation of `bin/browser.js`.

Here's an example from one of my projects:

`example_php.php`

```php
//...
$bs = Browsershot::url("index.html");
$bs -> addChromiumArguments(["no-sandbox"]);
$bs -> setBinPath(dirname(__DIR__) . "/libs/browsershot.js");
//...
```

`browsershot.js`

```javascript
const path = require("path");
const puppeteer = require("puppeteer-extra");
const puppeteerAdblock = require("puppeteer-extra-plugin-adblocker");
const puppeteerStealth = require("puppeteer-extra-plugin-stealth");

const dir = path.dirname(__dirname);
const script = `${dir}/vendor/spatie/browsershot/bin/browser.js`;
const browser = require(script);

puppeteer.use(puppeteerAdblock({blockTrackers: true}));
puppeteer.use(puppeteerStealth());
browser.callChrome(puppeteer);
```

Note that now I only need a few lines of JavaScript to setup my custom puppeteer instance which I can then pass to Browsershot without having to re-implement anything else within `bin/browser.js`.

**Tests** - can't see any for the relevant file...?

**API changes** - No breaking API changes.